### PR TITLE
Fix function comments typo 

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -198,7 +198,7 @@ func (w *packetWriter) Bytes() ([]byte, error) {
 	return (w.wb.Bytes())[:len], nil
 }
 
-// WriteInt appends the byte of b to the inner buffer, growing the buffer as
+// WriteByte appends the byte of b to the inner buffer, growing the buffer as
 // needed.
 func (w *packetWriter) WriteByte(b byte) {
 	if w.err != nil {
@@ -307,7 +307,7 @@ func (r *packetReader) ReadByte() byte {
 	return b
 }
 
-// Read reads structured binary data from r into data.
+// ReadInt reads reads structured binary data from r into data.
 // Data must be a pointer to a fixed-size value or a slice
 // of fixed-size values.
 // Bytes read from r are decoded using the specified byte order

--- a/server.go
+++ b/server.go
@@ -59,7 +59,7 @@ type Handler interface {
 // after sending back the corresponding response.
 type HandlerFunc func(*Response, *Packet, *log.Logger) (bool, error)
 
-// ServeHTTP calls f(r, p).
+// ServeCmpp calls f(r, p).
 func (f HandlerFunc) ServeCmpp(r *Response, p *Packet, l *log.Logger) (bool, error) {
 	return f(r, p, l)
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?